### PR TITLE
Ajusta link para href

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -128,7 +128,7 @@
                 <a href="#about"
                   class=" text-white ubl-bg-green border-0  text-center px-4 sm:px-9 py-2  focus:outline-none font-semibold rounded text-lg"><i
                     class="fa-solid fa-glasses mt-1 mr-2"></i> Sobre nós</a>
-                <a onclick="window.location.href =`https://github.com/Universidade-Livre`"
+                <a href="https://github.com/Universidade-Livre"
                   class="ml-4  text-white ubl-bg-blue px-6 sm:px-9 text-center border-0 py-2 focus:outline-none font-semibold rounded text-lg"><i
                     class="fa-brands fa-github mt-1 mr-2"></i> Github</a>
               </div>


### PR DESCRIPTION
O window.location não deixa o botão como um link. Não vejo o motivo de usar ele, acredito que seja melhor o href mesmo, mantendo o padrão de todo o site.