### PR TITLE
Realoca tag section da navbar para dentro da tag <aside>

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -104,7 +104,6 @@
               </div>
             </div>
           </nav>
-          </section>
       </section>
 
       <section class=" flex items-center justify-center h-[80%] ">
@@ -137,11 +136,10 @@
         </section>
 
       </section>
-
+    </section>
 
   </aside>
 
-  </section>
 
   <section class="text-gray-600 body-font sm:-mt-20 -mt-6">
     <div class="container  mx-auto">

--- a/docs/index.html
+++ b/docs/index.html
@@ -104,7 +104,7 @@
               </div>
             </div>
           </nav>
-
+          </section>
       </section>
 
       <section class=" flex items-center justify-center h-[80%] ">


### PR DESCRIPTION
 ~~Uma das tags section na navbar não estava fechada, o que impedia o funcionamento correto dos links. Este PR faz com que os links voltem a ser clicáveis como esperado.~~
 ~~Corrige #8~~

Apenas a tag estava fechada fora da tag _aside_, como o amigo disse abaixo, os navegadores ignoraram e passa despercebido, este PR não resolve o problema citado anteriormente e portanto fica como sugestão apenas para formatação do código.