### PR TITLE
fix: ajustes no z-index para tornar a navbar clicável

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -44,7 +44,7 @@
     <section class="bg-gradient-to-t   h-full from-gray-800 bg-gray-900/80">
       <section class="px-3 sm:px-7 pt-4 ">
         <div>
-          <nav class="shadow-2xl shadow-gray-900 rounded-3xl scale_up  ubl-bg-gradient">
+          <nav class="shadow-2xl shadow-gray-900 rounded-3xl scale_up  ubl-bg-gradient" style="position: relative; z-index: 50;">
             <div class="max-w-7xl sm:max-w-[90%] mx-auto   ">
               <div class="flex items-center justify-between h-16  px-6 ">
                 <div class="w-full justify-between flex items-center ">


### PR DESCRIPTION
### **Correção relacionada**
(Close) Issue: Menu de navegação não clicável em telas medianas [#15](https://github.com/Universidade-Livre/universidade-livre.github.io/issues/15)

Correção de um bug no menu de navegação principal que não estava respondendo a interações do usuário (cliques) em telas de tamanho mediano. A causa do problema era a sobreposição da `div` da seção inicial sobre a `navbar`, impedindo qualquer interação.

A solução aplicada foi a definição explícita da ordem de empilhamento (z-index) do menu, garantindo que ele permaneça acima dos outros elementos da página. Foi adicionado o estilo inline `style="position: relative; z-index: 50;"` à `nav`. A escolha por estilo inline se deu por conta da utilização de uma versão mais antiga do TailwindCSS no projeto (e eu não tenho familiaridade com ela).

### **Tipo de mudança:**

- [ ] Nova funcionalidade
- [x] Correção de bug
- [ ] Refatoração
- [ ] Melhoria de performance
- [ ] Documentação

### **Checklist:**

- [x] O código compila/roda corretamente.
- [x] Testes foram realizados (visuais/manuais para confirmar a interatividade do menu).
- [x] Nenhum erro novo está presente nos logs.

### **Testes realizados:**

- [x] Verificado que o menu de navegação voltou a ser funcional e clicável em telas medianas.
- [x] Confirmado que o layout e o estilo visual da `navbar` permanecem corretos e inalterados após a aplicação da correção.

### **O problema:**

No vídeo abaixo, é possível ver a realização de testes no navegador Google Chrome. Nele, eu redimensiono a janela para diferentes tamanhos, utilizando a extensão "Pesticide" para visualizar o comportamento dos blocos. É possível notar que o bloco da página inicial se sobrepõe ao menu em determinados tamanhos de tela.

https://github.com/user-attachments/assets/c45e442e-9829-4a72-aaae-4857fed7aa41

### **A solução:**

No video abaixo reproduzo as mesmas ações feitas no de cima, nele é possivel ver que agora a div de container da pagina inicial fica atras do menu, nao atrabalhando mais os cliques em telas medianas.


[Screencast from 2025-07-06 23-31-59.webm](https://github.com/user-attachments/assets/35a4e744-494f-45a0-977d-9bf5470656c0)

